### PR TITLE
fix: use moisture device class for SGS01

### DIFF
--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -254,8 +254,8 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                 TuyaBLESensorMapping(
                     dp_id=3,
                     description=SensorEntityDescription(
-                        key="humidity",
-                        device_class=SensorDeviceClass.HUMIDITY,
+                        key="moisture",
+                        device_class=SensorDeviceClass.MOISTURE,
                         native_unit_of_measurement=PERCENTAGE,
                         state_class=SensorStateClass.MEASUREMENT,
                     ),


### PR DESCRIPTION
The SGS01 implementation in this integration currently reports humidity but should report moisture instead.