### PR TITLE
initial support for cover platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ The integration works locally, but connection to Tuya BLE device requires device
   + Irrigation computer (product_id '6pahkcau')
   + 2-outlet irrigation computer SGW02 (product_id 'hfgdqhho'), also known as MOES BWV-YC02-EU-GY
 
+* Covers (category_id 'cl')
+  + Moes Roller Blind Motor (product_id '4pbr8eig')
+
 ## Support project
 
 I am working on this integration in Ukraine. Our country was subjected to brutal aggression by Russia. The war still continues. The capital of Ukraine - Kyiv, where I live, and many other cities and villages are constantly under threat of rocket attacks. Our air defense forces are doing wonders, but they also need support. So if you want to help the development of this integration, donate some money and I will spend it to support our air defense.

--- a/custom_components/tuya_ble/__init__.py
+++ b/custom_components/tuya_ble/__init__.py
@@ -27,6 +27,7 @@ PLATFORMS: list[Platform] = [
     Platform.SELECT,
     Platform.SWITCH,
     Platform.TEXT,
+    Platform.COVER,
 ]
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/tuya_ble/cover.py
+++ b/custom_components/tuya_ble/cover.py
@@ -76,7 +76,7 @@ mapping: dict[str, TuyaBLECategoryCoverMapping] = {
     "cl": TuyaBLECategoryCoverMapping(
         products={
             **dict.fromkeys([
-                "4pbr8eig", "qqdxfdht"
+                "4pbr8eig", "qqdxfdht", "kcy0xpi"
             ],
             [TuyaBLECoverMapping( # BLE Blind Controller
                 description=CoverEntityDescription(

--- a/custom_components/tuya_ble/cover.py
+++ b/custom_components/tuya_ble/cover.py
@@ -76,7 +76,7 @@ mapping: dict[str, TuyaBLECategoryCoverMapping] = {
     "cl": TuyaBLECategoryCoverMapping(
         products={
             **dict.fromkeys([
-                "4pbr8eig", "qqdxfdht", "kcy0x4pi"
+                "4pbr8eig", "qqdxfdht"
             ],
             [TuyaBLECoverMapping( # BLE Blind Controller
                 description=CoverEntityDescription(
@@ -92,15 +92,15 @@ mapping: dict[str, TuyaBLECategoryCoverMapping] = {
                 cover_set_upper_limit_dp_id=102,
                 cover_factory_reset_dp_id=107
             )]),
-            # "...": [TuyaBLECoverMapping(
-            #     description=CoverEntityDescription(
-            #         key="ble_curtain_controller"
-            #     ),
-            #     cover_state_dp_id=1,
-            #     cover_position_dp_id=3,
-            #     cover_position_set_dp=2,
-            #     cover_battery_dp_id=13
-            # )] # https://github.com/PlusPlus-ua/ha_tuya_ble/issues/126
+            "kcy0x4pi": [TuyaBLECoverMapping(
+                description=CoverEntityDescription(
+                    key="ble_curtain_controller"
+                ),
+                cover_state_dp_id=1,
+                cover_position_dp_id=3,
+                cover_position_set_dp=2,
+                cover_battery_dp_id=13
+            )]
         },
     ),
 }
@@ -145,7 +145,7 @@ class TuyaBLECover(TuyaBLEEntity, CoverEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        _LOGGER.debug("Updated data for %s: %s", self._device.name, self._device.datapoints)
+        _LOGGER.debug("Updated data for %s: %s", self._device.name, self._device.datapoints.__dict__())
         if self._mapping.cover_state_dp_id != 0:
             datapoint = self._device.datapoints[self._mapping.cover_state_dp_id]
             if datapoint:

--- a/custom_components/tuya_ble/cover.py
+++ b/custom_components/tuya_ble/cover.py
@@ -1,0 +1,210 @@
+"""The Tuya BLE integration."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import logging
+from typing import Callable
+
+from homeassistant.components.cover import (
+    CoverEntityDescription,
+    CoverEntityFeature,
+    CoverEntity,
+    STATE_CLOSED,
+    STATE_OPEN,
+    ATTR_POSITION
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN
+from .devices import TuyaBLEData, TuyaBLEEntity, TuyaBLEProductInfo
+from .tuya_ble import TuyaBLEDataPoint, TuyaBLEDataPointType, TuyaBLEDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+TUYA_COVER_STATE_MAP = {
+    0: STATE_OPEN,
+    2: STATE_CLOSED
+}
+
+@dataclass
+class TuyaBLECoverMapping:
+    description: CoverEntityDescription
+
+    cover_state_dp_id: int = 0
+    cover_position_dp_id: int = 0
+    cover_opening_mode_dp_id: int = 0
+    cover_work_state_dp_id: int = 0
+    cover_battery_dp_id: int = 0
+    cover_motor_direction_dp_id: int = 0
+    cover_set_upper_limit_dp_id: int = 0
+    cover_factory_reset_dp_id: int = 0
+    cover_position_set_dp: int = 0
+
+
+@dataclass
+class TuyaBLECategoryCoverMapping:
+    products: dict[str, list[TuyaBLECoverMapping]] | None = None
+    mapping: list[TuyaBLECoverMapping] | None = None
+
+
+mapping: dict[str, TuyaBLECategoryCoverMapping] = {
+    "cl": TuyaBLECategoryCoverMapping(
+        products={
+            **dict.fromkeys(
+                [
+                "4pbr8eig",
+                ],  # BLE Blind Controller
+                [
+                # Blind Controller
+                # - [X] 1   - State (0=open, 1=stop, 2=close)
+                # - [X] 3   - Position (RAW)
+                # - [ ] 4   - Opening Mode
+                # - [ ] 5   - UNKNOWN?
+                # - [ ] 7   - Work State (0=stdby, 1=success, 2=learning)
+                # - [ ] 13  - Battery
+                # - [ ] 101 - Direction
+                # - [ ] 102 - Upper Limit
+                # - [ ] 103 - UNKNOWN? DT_BOOL
+                # - [ ] 104 - UNKNOWN? DT_BOOL
+                # - [ ] 105 - UNKNOWN? DT_VALUE
+                # - [ ] 107 - Reset
+                TuyaBLECoverMapping(
+                    description=CoverEntityDescription(
+                        key="ble_blind_controller",
+                    ),
+                    cover_state_dp_id=1,
+                    cover_position_set_dp=2,
+                    cover_position_dp_id=3,
+                    cover_opening_mode_dp_id=4,
+                    cover_work_state_dp_id=7,
+                    cover_battery_dp_id=13,
+                    cover_motor_direction_dp_id=101,
+                    cover_set_upper_limit_dp_id=102,
+                    cover_factory_reset_dp_id=107
+                    ),
+                ],
+            ),
+        },
+    ),
+}
+
+
+def get_mapping_by_device(device: TuyaBLEDevice) -> list[TuyaBLECategoryCoverMapping]:
+    category = mapping.get(device.category)
+    if category is not None and category.products is not None:
+        product_mapping = category.products.get(device.product_id)
+        if product_mapping is not None:
+            return product_mapping
+        if category.mapping is not None:
+            return category.mapping
+        else:
+            return []
+    else:
+        return []
+
+
+class TuyaBLECover(TuyaBLEEntity, CoverEntity):
+    """Representation of a Tuya BLE Cover."""
+
+    _attr_is_closed = False
+    _attr_current_cover_position = 0
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: DataUpdateCoordinator,
+        device: TuyaBLEDevice,
+        product: TuyaBLEProductInfo,
+        mapping: TuyaBLECoverMapping,
+    ) -> None:
+        super().__init__(hass, coordinator, device, product, mapping.description)
+        self._mapping = mapping
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        _LOGGER.debug("Updated data for %s: %s", self._device.name, self._device.datapoints)
+        if self._mapping.cover_state_dp_id != 0:
+            datapoint = self._device.datapoints[self._mapping.cover_state_dp_id]
+            if datapoint:
+                if datapoint.value == 0:
+                    self._attr_is_opening = True
+                if datapoint.value == 1:
+                    self._attr_is_opening = False
+                    self._attr_is_closing = False
+                if datapoint.value == 2:
+                    self._attr_is_closing = True
+
+        if self._mapping.cover_position_dp_id != 0:
+            datapoint = self._device.datapoints[self._mapping.cover_position_dp_id]
+            if datapoint:
+                self._attr_current_cover_position = 100 - int(datapoint.value) # reverse position
+                if self._attr_current_cover_position == 0:
+                    self._attr_is_closed = True
+                if self._attr_current_cover_position == 100:
+                    self._attr_is_closed = False
+
+        self.async_write_ha_state()
+
+    async def async_open_cover(self, **kwargs) -> None:
+        """Open a cover."""
+        _LOGGER.debug("Call to open cover %s", self._device.name)
+        if self._mapping.cover_position_set_dp != 0:
+            datapoint = self._device.datapoints.get_or_create(
+                self._mapping.cover_position_set_dp,
+                TuyaBLEDataPointType.DT_VALUE,
+                100,
+            )
+            if datapoint:
+                self._hass.create_task(datapoint.set_value(100))
+
+    async def async_close_cover(self, **kwargs) -> None:
+        """Set new target temperature."""
+        _LOGGER.debug("Call to close cover %s", self._device.name)
+        if self._mapping.cover_position_set_dp != 0:
+            datapoint = self._device.datapoints.get_or_create(
+                self._mapping.cover_position_set_dp,
+                TuyaBLEDataPointType.DT_VALUE,
+                0,
+            )
+            if datapoint:
+                self._hass.create_task(datapoint.set_value(0))
+
+    async def async_set_cover_position(self, **kwargs: logging.Any) -> None:
+        """Set cover position"""
+        position = 100 - kwargs[ATTR_POSITION]
+        if self._mapping.cover_position_set_dp != 0:
+            datapoint = self._device.datapoints.get_or_create(
+                self._mapping.cover_position_set_dp,
+                TuyaBLEDataPointType.DT_VALUE,
+                position
+            )
+            if datapoint:
+                self._hass.create_task(datapoint.set_value(position))
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Tuya BLE sensors."""
+    data: TuyaBLEData = hass.data[DOMAIN][entry.entry_id]
+    mappings = get_mapping_by_device(data.device)
+    entities: list[TuyaBLECover] = []
+    for mapping in mappings:
+        entities.append(
+            TuyaBLECover(
+                hass,
+                data.coordinator,
+                data.device,
+                data.product,
+                mapping,
+            )
+        )
+    async_add_entities(entities)

--- a/custom_components/tuya_ble/cover.py
+++ b/custom_components/tuya_ble/cover.py
@@ -67,6 +67,11 @@ class TuyaBLECategoryCoverMapping:
 # - [ ] 107 - Reset
 
 # Curtain Controller
+# - [X] 1   - State (0=open, 1=stop, 2=close)
+# - [X] 2   - Position Set
+# - [X] 3   - Position (RAW)
+# - [X] 13  - Battery (RAW)
+
 
 mapping: dict[str, TuyaBLECategoryCoverMapping] = {
     "cl": TuyaBLECategoryCoverMapping(

--- a/custom_components/tuya_ble/cover.py
+++ b/custom_components/tuya_ble/cover.py
@@ -76,7 +76,7 @@ mapping: dict[str, TuyaBLECategoryCoverMapping] = {
     "cl": TuyaBLECategoryCoverMapping(
         products={
             **dict.fromkeys([
-                "4pbr8eig", "qqdxfdht", "kcy0xpi"
+                "4pbr8eig", "qqdxfdht", "kcy0x4pi"
             ],
             [TuyaBLECoverMapping( # BLE Blind Controller
                 description=CoverEntityDescription(

--- a/custom_components/tuya_ble/cover.py
+++ b/custom_components/tuya_ble/cover.py
@@ -170,8 +170,11 @@ class TuyaBLECover(TuyaBLEEntity, CoverEntity):
 
     async def async_open_cover(self, **kwargs) -> None:
         """Open a cover."""
-        if self._mapping.cover_state_dp_id != 0:
-            await self.async_set_cover_position(position=100)
+        await self.async_set_cover_position(position=100)
+        # sometimes the device does not update DP 1 so force the current state
+        if self._attr_current_cover_position != 100:
+            self._attr_is_opening = True
+            self.async_write_ha_state()
 
     async def async_stop_cover(self, **kwargs: logging.Any) -> None:
         """Stop a cover."""
@@ -186,8 +189,11 @@ class TuyaBLECover(TuyaBLEEntity, CoverEntity):
 
     async def async_close_cover(self, **kwargs) -> None:
         """Set new target temperature."""
-        if self._mapping.cover_state_dp_id != 0:
-            await self.async_set_cover_position(position=0)
+        await self.async_set_cover_position(position=0)
+        # sometimes the device does not update DP 1 so force the current state
+        if self._attr_current_cover_position != 0:
+            self._attr_is_closing = True
+            self.async_write_ha_state()
 
     async def async_set_cover_position(self, **kwargs: logging.Any) -> None:
         """Set cover position"""

--- a/custom_components/tuya_ble/cover.py
+++ b/custom_components/tuya_ble/cover.py
@@ -52,43 +52,48 @@ class TuyaBLECategoryCoverMapping:
     mapping: list[TuyaBLECoverMapping] | None = None
 
 
+# Blind Controller
+# - [X] 1   - State (0=open, 1=stop, 2=close)
+# - [X] 3   - Position (RAW)
+# - [ ] 4   - Opening Mode
+# - [ ] 5   - UNKNOWN?
+# - [ ] 7   - Work State (0=stdby, 1=success, 2=learning)
+# - [ ] 13  - Battery
+# - [ ] 101 - Direction
+# - [ ] 102 - Upper Limit
+# - [ ] 103 - UNKNOWN? DT_BOOL
+# - [ ] 104 - UNKNOWN? DT_BOOL
+# - [ ] 105 - UNKNOWN? DT_VALUE
+# - [ ] 107 - Reset
+
+# Curtain Controller
+
 mapping: dict[str, TuyaBLECategoryCoverMapping] = {
     "cl": TuyaBLECategoryCoverMapping(
         products={
-            **dict.fromkeys(
-                [
-                "4pbr8eig",
-                ],  # BLE Blind Controller
-                [
-                # Blind Controller
-                # - [X] 1   - State (0=open, 1=stop, 2=close)
-                # - [X] 3   - Position (RAW)
-                # - [ ] 4   - Opening Mode
-                # - [ ] 5   - UNKNOWN?
-                # - [ ] 7   - Work State (0=stdby, 1=success, 2=learning)
-                # - [ ] 13  - Battery
-                # - [ ] 101 - Direction
-                # - [ ] 102 - Upper Limit
-                # - [ ] 103 - UNKNOWN? DT_BOOL
-                # - [ ] 104 - UNKNOWN? DT_BOOL
-                # - [ ] 105 - UNKNOWN? DT_VALUE
-                # - [ ] 107 - Reset
-                TuyaBLECoverMapping(
-                    description=CoverEntityDescription(
-                        key="ble_blind_controller",
-                    ),
-                    cover_state_dp_id=1,
-                    cover_position_set_dp=2,
-                    cover_position_dp_id=3,
-                    cover_opening_mode_dp_id=4,
-                    cover_work_state_dp_id=7,
-                    cover_battery_dp_id=13,
-                    cover_motor_direction_dp_id=101,
-                    cover_set_upper_limit_dp_id=102,
-                    cover_factory_reset_dp_id=107
-                    ),
-                ],
+            "4pbr8eig": TuyaBLECoverMapping( # BLE Blind Controller
+                description=CoverEntityDescription(
+                    key="ble_blind_controller",
+                ),
+                cover_state_dp_id=1,
+                cover_position_set_dp=2,
+                cover_position_dp_id=3,
+                cover_opening_mode_dp_id=4,
+                cover_work_state_dp_id=7,
+                cover_battery_dp_id=13,
+                cover_motor_direction_dp_id=101,
+                cover_set_upper_limit_dp_id=102,
+                cover_factory_reset_dp_id=107
             ),
+            "TEST": TuyaBLECoverMapping(
+                description=CoverEntityDescription(
+                    key="ble_curtain_controller"
+                ),
+                cover_state_dp_id=1,
+                cover_position_dp_id=3,
+                cover_position_set_dp=2,
+                cover_battery_dp_id=13
+            )
         },
     ),
 }

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -305,6 +305,18 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
             ),
         },
     ),
+    "cl": TuyaBLECategoryInfo(
+        products={
+            **dict.fromkeys(
+                [
+                    "4pbr8eig"
+                ],
+                TuyaBLEProductInfo(
+                    name="Blind Controller"
+                )
+            )
+        }
+    )
 }
 
 

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -309,11 +309,14 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
         products={
             **dict.fromkeys(
                 [
-                    "4pbr8eig", "kcy0x4pi"
+                    "4pbr8eig"
                 ],
                 TuyaBLEProductInfo(
                     name="Blind Controller"
                 )
+            ),
+            "kcy0x4pi": TuyaBLEProductInfo(
+                name="Curtain Controller"
             )
         }
     )

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -309,7 +309,7 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
         products={
             **dict.fromkeys(
                 [
-                    "4pbr8eig"
+                    "4pbr8eig", "kcy0xpi"
                 ],
                 TuyaBLEProductInfo(
                     name="Blind Controller"

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -309,7 +309,7 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
         products={
             **dict.fromkeys(
                 [
-                    "4pbr8eig", "kcy0xpi"
+                    "4pbr8eig", "kcy0x4pi"
                 ],
                 TuyaBLEProductInfo(
                     name="Blind Controller"

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -454,7 +454,7 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
     "cl": TuyaBLECategoryNumberMapping(
         products={
             **dict.fromkeys(
-                ["4pbr8eig", "qqdxfdht", "kcy0xpi"], [
+                ["4pbr8eig", "qqdxfdht", "kcy0x4pi"], [
                 TuyaBLENumberMapping(
                     dp_id=105,
                     description=NumberEntityDescription(

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -19,10 +19,9 @@ from homeassistant.const import (
     UnitOfVolume,
     UnitOfTemperature,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -453,6 +453,23 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
             ],
         },
     ),
+    "cl": TuyaBLECategoryNumberMapping(
+        products={
+            "4pbr8eig": [
+                TuyaBLENumberMapping(
+                    dp_id=105,
+                    description=NumberEntityDescription(
+                        key="cover_speed",
+                        icon="mdi:speedometer",
+                        native_max_value=40,
+                        native_min_value=1,
+                        native_step=1,
+                        mode=NumberMode.BOX
+                    )
+                )
+            ]
+        },
+    ),
 }
 
 

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -15,9 +15,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
-    TIME_MINUTES,
-    TIME_SECONDS,
-    VOLUME_MILLILITERS,
+    UnitOfTime,
+    UnitOfVolume,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -197,7 +196,7 @@ class TuyaBLEHoldTimeDescription(NumberEntityDescription):
     icon: str = "mdi:timer"
     native_max_value: float = 10
     native_min_value: float = 0
-    native_unit_of_measurement: str = TIME_SECONDS
+    native_unit_of_measurement: str = UnitOfTime.SECONDS
     native_step: float = 1
     entity_category: EntityCategory = EntityCategory.CONFIG
 
@@ -385,7 +384,7 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                         icon="mdi:timer",
                         native_max_value=120,
                         native_min_value=1,
-                        native_unit_of_measurement=TIME_MINUTES,
+                        native_unit_of_measurement=UnitOfTime.MINUTES,
                         native_step=1,
                         entity_category=EntityCategory.CONFIG,
                     ),
@@ -404,7 +403,7 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                         device_class=NumberDeviceClass.WATER,
                         native_max_value=5000,
                         native_min_value=0,
-                        native_unit_of_measurement=VOLUME_MILLILITERS,
+                        native_unit_of_measurement=UnitOfVolume.MILLILITERS,
                         native_step=1,
                         entity_category=EntityCategory.CONFIG,
                     ),
@@ -422,7 +421,7 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                         icon="mdi:timer",
                         native_max_value=1440,
                         native_min_value=1,
-                        native_unit_of_measurement=TIME_MINUTES,
+                        native_unit_of_measurement=UnitOfTime.MINUTES,
                         native_step=1,
                     ),
                 ),
@@ -435,7 +434,7 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                         icon="mdi:timer",
                         native_max_value=1440,
                         native_min_value=1,
-                        native_unit_of_measurement=TIME_MINUTES,
+                        native_unit_of_measurement=UnitOfTime.MINUTES,
                         native_step=1,
                     ),
                 ),
@@ -446,7 +445,7 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                         icon="mdi:timer",
                         native_max_value=1440,
                         native_min_value=1,
-                        native_unit_of_measurement=TIME_MINUTES,
+                        native_unit_of_measurement=UnitOfTime.MINUTES,
                         native_step=1,
                     ),
                 ),
@@ -455,7 +454,8 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
     ),
     "cl": TuyaBLECategoryNumberMapping(
         products={
-            "4pbr8eig": [
+            **dict.fromkeys(
+                ["4pbr8eig", "qqdxfdht"], [
                 TuyaBLENumberMapping(
                     dp_id=105,
                     description=NumberEntityDescription(
@@ -467,7 +467,7 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                         mode=NumberMode.BOX
                     )
                 )
-            ]
+            ])
         },
     ),
 }

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -454,7 +454,7 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
     "cl": TuyaBLECategoryNumberMapping(
         products={
             **dict.fromkeys(
-                ["4pbr8eig", "qqdxfdht"], [
+                ["4pbr8eig", "qqdxfdht", "kcy0xpi"], [
                 TuyaBLENumberMapping(
                     dp_id=105,
                     description=NumberEntityDescription(

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -42,7 +42,6 @@ class TemperatureUnitDescription(SelectEntityDescription):
     icon: str = "mdi:thermometer"
     entity_category: EntityCategory = EntityCategory.CONFIG
 
-
 @dataclass
 class TuyaBLEFingerbotModeMapping(TuyaBLESelectMapping):
     description: SelectEntityDescription = field(
@@ -170,33 +169,6 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                         options=[
                             "interval_reminder",
                             "schedule_reminder",
-                        ],
-                        entity_category=EntityCategory.CONFIG,
-                    ),
-                ),
-            ],
-        },
-    ),
-    "znhsb": TuyaBLECategorySelectMapping(
-        products={
-            "cdlandip":  # Smart water bottle
-            [
-                TuyaBLESelectMapping(
-                    dp_id=106,
-                    description=TemperatureUnitDescription(
-                        options=[
-                            UnitOfTemperature.CELSIUS,
-                            UnitOfTemperature.FAHRENHEIT,
-                        ],
-                    )
-                ),
-                TuyaBLESelectMapping(
-                    dp_id=107,
-                    description=SelectEntityDescription(
-                        key="reminder_mode",
-                        options=[
-                            "interval_reminder",
-                            "alarm_reminder",
                         ],
                         entity_category=EntityCategory.CONFIG,
                     ),

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -41,11 +41,6 @@ class TemperatureUnitDescription(SelectEntityDescription):
     key: str = "temperature_unit"
     icon: str = "mdi:thermometer"
     entity_category: EntityCategory = EntityCategory.CONFIG
-    entity_registry_enabled_default = True
-    options: list[str] | None = [
-        UnitOfTemperature.CELSIUS,
-        UnitOfTemperature.FAHRENHEIT,
-    ]
 
 @dataclass
 class TuyaBLEFingerbotModeMapping(TuyaBLESelectMapping):
@@ -76,7 +71,12 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
             [
                 TuyaBLESelectMapping(
                     dp_id=101,
-                    description=TemperatureUnitDescription()
+                    description=TemperatureUnitDescription(
+                        options=[
+                            UnitOfTemperature.CELSIUS,
+                            UnitOfTemperature.FAHRENHEIT,
+                        ],
+                    )
                 ),
             ],
         },
@@ -139,6 +139,10 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                 TuyaBLESelectMapping(
                     dp_id=9,
                     description=TemperatureUnitDescription(
+                        options=[
+                            UnitOfTemperature.CELSIUS,
+                            UnitOfTemperature.FAHRENHEIT,
+                        ],
                         entity_registry_enabled_default=False,
                     )
                 ),
@@ -151,7 +155,12 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
             [
                 TuyaBLESelectMapping(
                     dp_id=106,
-                    description=TemperatureUnitDescription()
+                    description=TemperatureUnitDescription(
+                        options=[
+                            UnitOfTemperature.CELSIUS,
+                            UnitOfTemperature.FAHRENHEIT,
+                        ],
+                    )
                 ),
                 TuyaBLESelectMapping(
                     dp_id=107,

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -41,6 +41,11 @@ class TemperatureUnitDescription(SelectEntityDescription):
     key: str = "temperature_unit"
     icon: str = "mdi:thermometer"
     entity_category: EntityCategory = EntityCategory.CONFIG
+    entity_registry_enabled_default = True
+    options: list[str] | None = [
+        UnitOfTemperature.CELSIUS,
+        UnitOfTemperature.FAHRENHEIT,
+    ]
 
 @dataclass
 class TuyaBLEFingerbotModeMapping(TuyaBLESelectMapping):
@@ -71,12 +76,7 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
             [
                 TuyaBLESelectMapping(
                     dp_id=101,
-                    description=TemperatureUnitDescription(
-                        options=[
-                            UnitOfTemperature.CELSIUS,
-                            UnitOfTemperature.FAHRENHEIT,
-                        ],
-                    )
+                    description=TemperatureUnitDescription()
                 ),
             ],
         },
@@ -139,10 +139,6 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                 TuyaBLESelectMapping(
                     dp_id=9,
                     description=TemperatureUnitDescription(
-                        options=[
-                            UnitOfTemperature.CELSIUS,
-                            UnitOfTemperature.FAHRENHEIT,
-                        ],
                         entity_registry_enabled_default=False,
                     )
                 ),
@@ -155,12 +151,7 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
             [
                 TuyaBLESelectMapping(
                     dp_id=106,
-                    description=TemperatureUnitDescription(
-                        options=[
-                            UnitOfTemperature.CELSIUS,
-                            UnitOfTemperature.FAHRENHEIT,
-                        ],
-                    )
+                    description=TemperatureUnitDescription()
                 ),
                 TuyaBLESelectMapping(
                     dp_id=107,

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -370,6 +370,7 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                         description=SensorEntityDescription(
                             key="cover_work_state",
                             entity_category=EntityCategory.DIAGNOSTIC,
+                            device_class=SensorDeviceClass.ENUM,
                             options=[
                                 "STANDBY",
                                 "SUCCESS",

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -360,6 +360,16 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
             ],
         },
     ),
+    "cl": TuyaBLECategorySensorMapping(
+        products={
+            **dict.fromkeys(
+                ["4pbr8eig"], # Blind Controller
+                [
+                    TuyaBLEBatteryMapping(dp_id=13),
+                ],
+            ),
+        }
+    ),
 }
 def rssi_getter(sensor: TuyaBLESensor) -> None:
     sensor._attr_native_value = sensor._device.rssi

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -362,7 +362,7 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
     "cl": TuyaBLECategorySensorMapping(
         products={
             **dict.fromkeys(
-                ["4pbr8eig", "qqdxfdht"], # Blind Controller
+                ["4pbr8eig", "qqdxfdht", "kcy0xpi"], # Blind Controller
                 [
                     TuyaBLEBatteryMapping(dp_id=13),
                     TuyaBLESensorMapping(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -14,10 +14,9 @@ from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-    TEMP_CELSIUS,
-    VOLUME_MILLILITERS,
     UnitOfTemperature,
-    UnitOfTime
+    UnitOfTime,
+    UnitOfVolume
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
@@ -305,7 +304,7 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     description=SensorEntityDescription(
                         key="water_intake",
                         device_class=SensorDeviceClass.WATER,
-                        native_unit_of_measurement=VOLUME_MILLILITERS,
+                        native_unit_of_measurement=UnitOfVolume.MILLILITERS,
                         state_class=SensorStateClass.MEASUREMENT,
                     ),
                 ),
@@ -363,9 +362,21 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
     "cl": TuyaBLECategorySensorMapping(
         products={
             **dict.fromkeys(
-                ["4pbr8eig"], # Blind Controller
+                ["4pbr8eig", "qqdxfdht"], # Blind Controller
                 [
                     TuyaBLEBatteryMapping(dp_id=13),
+                    TuyaBLESensorMapping(
+                        dp_id=7,
+                        description=SensorEntityDescription(
+                            key="cover_work_state",
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                            options=[
+                                "STANDBY",
+                                "SUCCESS",
+                                "LEARNING"
+                            ]
+                        )
+                    )
                 ],
             ),
         }

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -362,7 +362,7 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
     "cl": TuyaBLECategorySensorMapping(
         products={
             **dict.fromkeys(
-                ["4pbr8eig", "qqdxfdht", "kcy0xpi"], # Blind Controller
+                ["4pbr8eig", "qqdxfdht", "kcy0x4pi"], # Blind Controller
                 [
                     TuyaBLEBatteryMapping(dp_id=13),
                     TuyaBLESensorMapping(

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -230,6 +230,14 @@
       "program": {
         "name": "Program: position[/time];..."
       }
+    },
+    "cover": {
+      "ble_blind_controller": {
+        "name": "Blind Motor"
+      },
+      "ble_curtain_controller": {
+        "name": "Curtain Motor"
+      }
     }
   },
   "options": {

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -70,6 +70,9 @@
       },
       "countdown_duration_z2": {
         "name": "Irrigation duration - Zone 2"
+      },
+      "cover_speed": {
+        "name": "Motor Speed"
       }
     },
     "select": {
@@ -168,6 +171,9 @@
       },
       "use_time_z2": {
           "name": "Last irrigation time - Zone 2"
+      },
+      "cover_work_state": {
+        "name": "Current State"
       }
     },
     "switch": {

--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -152,6 +152,9 @@ class TuyaBLEDataPoints:
     def __getitem__(self, key: int) -> TuyaBLEDataPoint | None:
         return self._datapoints.get(key)
 
+    def __dict__(self) -> dict:
+        return self._datapoints
+
     def has_id(self, id: int, type: TuyaBLEDataPointType | None = None) -> bool:
         return (id in self._datapoints) and (
             (type is None) or (self._datapoints[id].type == type)


### PR DESCRIPTION
As this fork is the most up to date, I've started to add support for the cover platform. MCU datapoints appear to be identical to the ones for the ZigBee MCU of the same device (only difference is the BLE chip) on the logic board inside.

https://github.com/Koenkk/zigbee-herdsman-converters/blob/7d058d9ae369853005a6533d8111fb390a1ed29e/src/devices/tuya.ts#L4230

Currently to do:

- [x] `cover.open`
- [x] `cover.close`
- [ ] `cover.stop` - not supported, cannot find a DP to enable this.
- [X] `cover.set_position`

The specific model I have brought is a Moes based blind controller (AM43-0.45/40-ES-EB [TY]). When pairing make sure the smart life app is connected to the device otherwise the integration was throwing an error that the device was not registered.

These blind controllers only handle one connection at a time, so connecting will be hit and miss if you try and connect something else to them.

For documentation purposes, these blinds also have a UART header on the logic board (although nothing soldered onto it) to access the MCU directly. With power buttons facing down, and the buttons facing behind:

GND
TX
RX
3.3V

![image](https://github.com/user-attachments/assets/47ede783-6d31-44e0-9af4-81afb1eb96aa)
