### PR TITLE
Add support for more device_ids for dual outlet irrigation computers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ The integration works locally, but connection to Tuya BLE device requires device
 
 * Irrigation computer (category_id 'ggq')
   + Irrigation computer (product_id '6pahkcau')
-  + 2-outlet irrigation computer (product_ids 'hfgdqhho', 'fnlw6npo', 'qycalacn'), also known as SGW02, SGW08, and MOES BWV-YC02-EU-GY
+  + 2-outlet irrigation computer (product_ids 'hfgdqhho', 'fnlw6npo', 'qycalacn', 'jjqi2syk')
+    - also known as: SGW02, SGW08, MOES BWV-YC02-EU-GY, Kogan SmarterHome KASMWATMRDA / KASMWTV2LVA
 
 ## Support project
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The integration works locally, but connection to Tuya BLE device requires device
 
 * Irrigation computer (category_id 'ggq')
   + Irrigation computer (product_id '6pahkcau')
-  + 2-outlet irrigation computer SGW02 (product_id 'hfgdqhho'), also known as MOES BWV-YC02-EU-GY
+  + 2-outlet irrigation computer (product_ids 'hfgdqhho', 'fnlw6npo', 'qycalacn'), also known as SGW02, SGW08, and MOES BWV-YC02-EU-GY
 
 ## Support project
 

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -298,6 +298,8 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
                 [
                 "6pahkcau", 
                 "hfgdqhho",
+                "qycalacn",
+                "fnlw6npo"
                 ],  # device product_id
                 TuyaBLEProductInfo( 
                     name="Irrigation computer",

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -296,11 +296,12 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
         products={
             **dict.fromkeys(
                 [
-                "6pahkcau", 
-                "hfgdqhho",
-                "qycalacn",
-                "fnlw6npo"
-                ],  # device product_id
+                    "6pahkcau", 
+                    "hfgdqhho",
+                    "qycalacn",
+                    "fnlw6npo",
+                    "jjqi2syk",
+                ],  # device product_ids
                 TuyaBLEProductInfo( 
                     name="Irrigation computer",
                 ),

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -427,30 +427,37 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                     ),
                 ),
             ],
-            "hfgdqhho": [  # Irrigation computer - SGW02
-                TuyaBLENumberMapping(
-                    dp_id=106,
-                    description=NumberEntityDescription(
-                        key="countdown_duration_z1",
-                        icon="mdi:timer",
-                        native_max_value=1440,
-                        native_min_value=1,
-                        native_unit_of_measurement=TIME_MINUTES,
-                        native_step=1,
+            **dict.fromkeys(
+                [
+                    "hfgdqhho",
+                    "qycalacn",
+                    "fnlw6npo"
+                ],  # Irrigation computer - SGW02, SGW08, BWV-YC02-EU-GY
+                [
+                    TuyaBLENumberMapping(
+                        dp_id=106,
+                        description=NumberEntityDescription(
+                            key="countdown_duration_z1",
+                            icon="mdi:timer",
+                            native_max_value=1440,
+                            native_min_value=1,
+                            native_unit_of_measurement=TIME_MINUTES,
+                            native_step=1,
+                        ),
                     ),
-                ),
-                TuyaBLENumberMapping(
-                    dp_id=103,
-                    description=NumberEntityDescription(
-                        key="countdown_duration_z2",
-                        icon="mdi:timer",
-                        native_max_value=1440,
-                        native_min_value=1,
-                        native_unit_of_measurement=TIME_MINUTES,
-                        native_step=1,
+                    TuyaBLENumberMapping(
+                        dp_id=103,
+                        description=NumberEntityDescription(
+                            key="countdown_duration_z2",
+                            icon="mdi:timer",
+                            native_max_value=1440,
+                            native_min_value=1,
+                            native_unit_of_measurement=TIME_MINUTES,
+                            native_step=1,
+                        ),
                     ),
-                ),
-            ],
+                ],
+            ),
         },
     ),
 }

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -431,8 +431,9 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                 [
                     "hfgdqhho",
                     "qycalacn",
-                    "fnlw6npo"
-                ],  # Irrigation computer - SGW02, SGW08, BWV-YC02-EU-GY
+                    "fnlw6npo",
+                    "jjqi2syk",
+                ],  # Irrigation computer - dual outlet
                 [
                     TuyaBLENumberMapping(
                         dp_id=106,

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -341,8 +341,9 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                 [
                     "hfgdqhho",
                     "qycalacn",
-                    "fnlw6npo"
-                ],  # Irrigation computer - SGW02, SGW08, BWV-YC02-EU-GY
+                    "fnlw6npo",
+                    "jjqi2syk",
+                ],  # Irrigation computer - dual outlet
                 [ 
                     TuyaBLEBatteryMapping(dp_id=11),
                     TuyaBLESensorMapping(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -337,27 +337,34 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     ),
                 ),
             ],
-            "hfgdqhho": [  # Irrigation computer - SGW02
-                TuyaBLEBatteryMapping(dp_id=11),
-                TuyaBLESensorMapping(
-                    dp_id=111,
-                    description=SensorEntityDescription(
-                        key="use_time_z1",
-                        device_class=SensorDeviceClass.DURATION,
-                        native_unit_of_measurement=UnitOfTime.SECONDS,
-                        state_class=SensorStateClass.MEASUREMENT,
+            **dict.fromkeys(
+                [
+                    "hfgdqhho",
+                    "qycalacn",
+                    "fnlw6npo"
+                ],  # Irrigation computer - SGW02, SGW08, BWV-YC02-EU-GY
+                [ 
+                    TuyaBLEBatteryMapping(dp_id=11),
+                    TuyaBLESensorMapping(
+                        dp_id=111,
+                        description=SensorEntityDescription(
+                            key="use_time_z1",
+                            device_class=SensorDeviceClass.DURATION,
+                            native_unit_of_measurement=UnitOfTime.SECONDS,
+                            state_class=SensorStateClass.MEASUREMENT,
+                        ),
                     ),
-                ),
-                TuyaBLESensorMapping(
-                    dp_id=110,
-                    description=SensorEntityDescription(
-                        key="use_time_z2",
-                        device_class=SensorDeviceClass.DURATION,
-                        native_unit_of_measurement=UnitOfTime.SECONDS,
-                        state_class=SensorStateClass.MEASUREMENT,
+                    TuyaBLESensorMapping(
+                        dp_id=110,
+                        description=SensorEntityDescription(
+                            key="use_time_z2",
+                            device_class=SensorDeviceClass.DURATION,
+                            native_unit_of_measurement=UnitOfTime.SECONDS,
+                            state_class=SensorStateClass.MEASUREMENT,
+                        ),
                     ),
-                ),
-            ],
+                ],
+            ),
         },
     ),
 }

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -326,22 +326,29 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
                     ),
                 ),
             ],
-            "hfgdqhho": [  # Irrigation computer
-                TuyaBLESwitchMapping(
-                    dp_id=105,
-                    description=SwitchEntityDescription(
-                        key="water_valve_z1",
-                        entity_registry_enabled_default=True,
+            **dict.fromkeys(
+                [
+                    "hfgdqhho",
+                    "qycalacn",
+                    "fnlw6npo"
+                ],  # Irrigation computer - SGW02, SGW08, BWV-YC02-EU-GY
+                [
+                    TuyaBLESwitchMapping(
+                        dp_id=105,
+                        description=SwitchEntityDescription(
+                            key="water_valve_z1",
+                            entity_registry_enabled_default=True,
+                        ),
                     ),
-                ),
-                TuyaBLESwitchMapping(
-                    dp_id=104,
-                    description=SwitchEntityDescription(
-                        key="water_valve_z2",
-                        entity_registry_enabled_default=True,
+                    TuyaBLESwitchMapping(
+                        dp_id=104,
+                        description=SwitchEntityDescription(
+                            key="water_valve_z2",
+                            entity_registry_enabled_default=True,
+                        ),
                     ),
-                ),
-            ],
+                ],
+            ),
         },
     ),
 }

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -330,8 +330,9 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
                 [
                     "hfgdqhho",
                     "qycalacn",
-                    "fnlw6npo"
-                ],  # Irrigation computer - SGW02, SGW08, BWV-YC02-EU-GY
+                    "fnlw6npo",
+                    "jjqi2syk",
+                ],  # Irrigation computer - dual outlet
                 [
                     TuyaBLESwitchMapping(
                         dp_id=105,


### PR DESCRIPTION
Extends / closes #8 with yet another device_id for dual outlet irrigation computers.